### PR TITLE
Added functionality to find and expose tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         pip uninstall -y "jupyter_server_ai_tools" jupyter_server
         rm -rf "jupyter_server_ai_tools"
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: my_server_extension-sdist
         path: my_server_extension.tar.gz
@@ -54,13 +54,16 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
 
   test_lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - name: Run Linters
-        run: |
-          bash ./.github/workflows/lint.sh
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+        - name: Install lint + test dependencies
+          run: pip install -e ".[lint,test]"
+
+        - name: Run Linters
+          run: bash ./.github/workflows/lint.sh
 
   check_release:
     runs-on: ubuntu-latest
@@ -76,7 +79,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Distributions
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: jupyter_server_ai_tools-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist
@@ -93,7 +96,7 @@ jobs:
       with:
         python-version: '3.8'
         architecture: 'x64'
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: my_server_extension-sdist
     - name: Install and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,43 +1,103 @@
-name: CI
+name: Build
 
 on:
   push:
     branches: ["main"]
   pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+defaults:
+  run:
+    shell: bash -eux {0}
 
 jobs:
-  lint-test-build:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [ '3.8', '3.9', '3.10', "3.11" ]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Base Setup
+      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+    - name: Install dependencies
+      run: python -m pip install -U jupyter_server
+
+    - name: Build the extension
+      run: |
+        python -m pip install .
+        jupyter server extension list 2>&1 | grep -ie "jupyter_server_ai_tools.*OK"
+
+        pip install build
+        python -m build --sdist
+        cp dist/*.tar.gz my_server_extension.tar.gz
+        pip uninstall -y "jupyter_server_ai_tools" jupyter_server
+        rm -rf "jupyter_server_ai_tools"
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: my_server_extension-sdist
+        path: my_server_extension.tar.gz
+
+  check_links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
+
+  test_lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Run Linters
+        run: |
+          bash ./.github/workflows/lint.sh
+
+  check_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Install Dependencies
+        run: |
+          pip install -e .
+      - name: Check Release
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Distributions
+        uses: actions/upload-artifact@v2
+        with:
+          name: jupyter_server_ai_tools-releaser-dist-${{ github.run_number }}
+          path: .jupyter_releaser_checkout/dist
+
+  test_sdist:
+    needs: build
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-
-      - name: Install dependencies
-        run: |
-          pip install -e ".[lint,test]"
-          pip install build pytest-jupyter
-
-      - name: Run lint and tests
-        run: bash .github/workflows/lint.sh
-
-      - name: Enable extension
-        run: |
-          jupyter server extension enable jupyter_server_ai_tools
-          jupyter server extension list 2>&1 | grep -ie "jupyter_server_ai_tools.*OK"
-
-      - name: Build sdist
-        run: |
-          python -m build --sdist
-          cp dist/*.tar.gz my_server_extension.tar.gz
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: my_server_extension-sdist
-          path: my_server_extension.tar.gz
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+        architecture: 'x64'
+    - uses: actions/download-artifact@v2
+      with:
+        name: my_server_extension-sdist
+    - name: Install and Test
+      run: |
+        pip install my_server_extension.tar.gz
+        pip install jupyter_server
+        jupyter server extension list 2>&1 | grep -ie "jupyter_server_ai_tools.*OK"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: my_server_extension-sdist
+        name: my_server_extension-sdist-${{ matrix.os }}-py${{ matrix.python-version }}
         path: my_server_extension.tar.gz
 
   check_links:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [ '3.8', '3.9', '3.10', "3.11" ]
+        python-version: ['3.9', '3.10', "3.11" ]
 
     steps:
     - name: Checkout
@@ -94,7 +94,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
         architecture: 'x64'
     - uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', "3.11" ]
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - name: Checkout
@@ -41,9 +41,11 @@ jobs:
         pip uninstall -y "jupyter_server_ai_tools" jupyter_server
         rm -rf "jupyter_server_ai_tools"
 
-    - uses: actions/upload-artifact@v4
+    - name: Upload artifact
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
+      uses: actions/upload-artifact@v4
       with:
-        name: my_server_extension-sdist-${{ matrix.os }}-py${{ matrix.python-version }}
+        name: my_server_extension-sdist
         path: my_server_extension.tar.gz
 
   check_links:
@@ -54,16 +56,16 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
 
   test_lint:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v2
-        - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-        - name: Install lint + test dependencies
-          run: pip install -e ".[lint,test]"
+      - name: Install lint + test dependencies
+        run: pip install -e ".[lint,test]"
 
-        - name: Run Linters
-          run: bash ./.github/workflows/lint.sh
+      - name: Run Linters
+        run: bash ./.github/workflows/lint.sh
 
   check_release:
     runs-on: ubuntu-latest
@@ -72,8 +74,7 @@ jobs:
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Install Dependencies
-        run: |
-          pip install -e .
+        run: pip install -e .
       - name: Check Release
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:
@@ -87,7 +88,6 @@ jobs:
   test_sdist:
     needs: build
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ ______________________________________________________________________
 
 - ✅ Simple, declarative `ToolDefinition` API
 - ✅ Automatic metadata inference from function signature and docstring
-- ✅ Optional schema validation using JSON Schema
+
 - ✅ Tool discovery across all installed Jupyter extensions
 - ✅ Clean separation between metadata and callable execution
 

--- a/README.md
+++ b/README.md
@@ -1,90 +1,105 @@
-# jupyter_server_ai_tools
+# 🧠 jupyter-server-ai-tools
 
-[![Github Actions Status](https://github.com/Abigayle-Mercer/jupyter-server-ai-tools/workflows/Build/badge.svg)](https://github.com/Abigayle-Mercer/jupyter-server-ai-tools/actions/workflows/build.yml)
+[![CI](https://github.com/Abigayle-Mercer/jupyter-server-ai-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/Abigayle-Mercer/jupyter-server-ai-tools/actions/workflows/ci.yml)
 
-A Jupyter Server extension.
+A Jupyter Server extension for discovering and aggregating callable tools from other extensions.
 
-## Requirements
+This project provides a structured way for extensions to declare tools using `ToolDefinition` objects, and for agents or other consumers to retrieve those tools — with optional metadata validation.
 
-- Jupyter Server
+______________________________________________________________________
 
-## Install
+## ✨ Features
 
-To install the extension, execute:
+- ✅ Simple, declarative `ToolDefinition` API
+- ✅ Automatic metadata inference from function signature and docstring
+- ✅ Optional schema validation using JSON Schema
+- ✅ Tool discovery across all installed Jupyter extensions
+- ✅ Clean separation between metadata and callable execution
+
+______________________________________________________________________
+
+## 📦 Install
 
 ```bash
 pip install jupyter_server_ai_tools
 ```
 
-## Uninstall
-
-To remove the extension, execute:
+To install for development:
 
 ```bash
-pip uninstall jupyter_server_ai_tools
+git clone https://github.com/Abigayle-Mercer/jupyter-server-ai-tools.git
+cd jupyter-server-ai-tools
+pip install -e ".[lint,test]"
 ```
 
-## Troubleshoot
+## Usage
 
-If you are seeing the frontend extension, but it is not working, check
-that the server extension is enabled:
+#### Expose tools in your own extensions:
 
-```bash
-jupyter server extension list
+```python
+from jupyter_server_ai_tools.models import ToolDefinition
+
+def greet(name: str):
+    """Say hello to someone."""
+    return f"Hello, {name}!"
+
+def jupyter_server_extension_tools():
+    return [ToolDefinition(callable=greet)]
 ```
 
-## Contributing
+#### Discover tools from all extensions:
 
-### Development install
+```python
+from jupyter_server_ai_tools.tool_registry import find_tools
 
-```bash
-# Clone the repo to your local environment
-# Change directory to the jupyter_server_ai_tools directory
-# Install package in development mode - will automatically enable
-# The server extension.
-pip install -e .
+tools = find_tools(extension_manager)
 ```
 
-You can watch the source directory and run your Jupyter Server-based application at the same time in different terminals to watch for changes in the extension's source and automatically rebuild the extension. For example,
-when running JupyterLab:
-
-```bash
-jupyter lab --autoreload
-```
-
-If your extension does not depend a particular frontend, you can run the
-server directly:
-
-```bash
-jupyter server --autoreload
-```
-
-### Running Tests
-
-Install dependencies:
+## 🧪 Running Tests
 
 ```bash
 pip install -e ".[test]"
+pytest
 ```
 
-To run the python tests, use:
+## 🧼 Linting and Formatting
 
 ```bash
-pytest
-
-# To test a specific file
-pytest jupyter_server_ai_tools/tests/test_handlers.py
-
-# To run a specific test
-pytest jupyter_server_ai_tools/tests/test_handlers.py -k "test_get"
+pip install -e ".[lint]"
+bash .github/workflows/lint.sh
 ```
 
-### Development uninstall
+## Tool Output Example
+
+Given the `greet()` tool above, `find_tools(return_metadata_only=True)` will return:
+
+```json
+[
+  {
+    "name": "greet",
+    "description": "Say hello to someone.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" }
+      },
+      "required": ["name"]
+    }
+  }
+]
+```
+
+## Impact
+
+This system enables:
+
+- Extension authors to register tools with minimal effort
+- Agent builders to dynamically discover and bind tools
+- Optional schema enforcement when needed
+- Future compatibility with MCP and OpenAPI-based agents
+
+## 🧹 Uninstall
 
 ```bash
 pip uninstall jupyter_server_ai_tools
 ```
-
-### Packaging the extension
-
-See [RELEASE](RELEASE.md)

--- a/jupyter_server_ai_tools/__init__.py
+++ b/jupyter_server_ai_tools/__init__.py
@@ -1,4 +1,7 @@
 from .extension import Extension
+from .tool_registry import find_tools
+
+__all__ = ["find_tools"]
 
 __version__ = "0.1.0"
 

--- a/jupyter_server_ai_tools/extension.py
+++ b/jupyter_server_ai_tools/extension.py
@@ -1,5 +1,24 @@
 from jupyter_server.extension.application import ExtensionApp
+from jupyter_server.utils import url_path_join
+from traitlets import Unicode
+
+from .handlers import ListToolInfoHandler
 
 
 class Extension(ExtensionApp):
-    name = "jupyter_server_ai_tools"
+    # Required traits
+    name = "jupyter-server-ai-tools"  # is this the right name?
+    default_url = Unicode("/jupyter-server-ai-tools").tag(config=True)
+    load_other_extensions = True
+
+    def initialize_handlers(self):
+        """Register API route handlers."""
+        assert self.serverapp is not None
+        base_url = self.serverapp.web_app.settings["base_url"]
+        route_pattern = url_path_join(base_url, self.default_url, "tools")
+
+        self.handlers.extend(
+            [
+                (route_pattern, ListToolInfoHandler),
+            ]
+        )

--- a/jupyter_server_ai_tools/extension.py
+++ b/jupyter_server_ai_tools/extension.py
@@ -7,18 +7,14 @@ from .handlers import ListToolInfoHandler
 
 class Extension(ExtensionApp):
     # Required traits
-    name = "jupyter-server-ai-tools"  # is this the right name?
-    default_url = Unicode("/jupyter-server-ai-tools").tag(config=True)
+    name = "jupyter_server_ai_tools"  # is this the right name?
+    default_url = Unicode("/jupyter_server_ai_tools").tag(config=True)
     load_other_extensions = True
 
     def initialize_handlers(self):
-        """Register API route handlers."""
         assert self.serverapp is not None
         base_url = self.serverapp.web_app.settings["base_url"]
         route_pattern = url_path_join(base_url, self.default_url, "tools")
-
-        self.handlers.extend(
-            [
-                (route_pattern, ListToolInfoHandler),
-            ]
-        )
+        self.serverapp.web_app.add_handlers(
+            ".*$", [(route_pattern, ListToolInfoHandler)]
+        )  # ✅ works

--- a/jupyter_server_ai_tools/extension.py
+++ b/jupyter_server_ai_tools/extension.py
@@ -15,6 +15,4 @@ class Extension(ExtensionApp):
         assert self.serverapp is not None
         base_url = self.serverapp.web_app.settings["base_url"]
         route_pattern = url_path_join(base_url, self.default_url, "tools")
-        self.serverapp.web_app.add_handlers(
-            ".*$", [(route_pattern, ListToolInfoHandler)]
-        )  # ✅ works
+        self.serverapp.web_app.add_handlers(".*$", [(route_pattern, ListToolInfoHandler)])

--- a/jupyter_server_ai_tools/handlers.py
+++ b/jupyter_server_ai_tools/handlers.py
@@ -1,0 +1,17 @@
+import json
+
+import tornado
+from jupyter_server.base.handlers import APIHandler
+
+from jupyter_server_ai_tools.tool_registry import find_tools
+
+
+class ListToolInfoHandler(APIHandler):
+    @tornado.web.authenticated
+    async def get(self):
+        metadata_only = True  # Optionally make this dynamic from query param later
+        assert self.serverapp is not None
+        raw_tools = find_tools(self.serverapp.extension_manager, return_metadata_only=metadata_only)
+
+        # If metadata_only=True, raw_tools is already safe
+        self.finish(json.dumps({"discovered_tools": raw_tools}))

--- a/jupyter_server_ai_tools/handlers.py
+++ b/jupyter_server_ai_tools/handlers.py
@@ -12,6 +12,5 @@ class ListToolInfoHandler(APIHandler):
         metadata_only = True
         assert self.serverapp is not None
         raw_tools = find_tools(self.serverapp.extension_manager, return_metadata_only=metadata_only)
-
         # If metadata_only=True, raw_tools is already safe
         self.finish(json.dumps({"discovered_tools": raw_tools}))

--- a/jupyter_server_ai_tools/handlers.py
+++ b/jupyter_server_ai_tools/handlers.py
@@ -9,7 +9,7 @@ from jupyter_server_ai_tools.tool_registry import find_tools
 class ListToolInfoHandler(APIHandler):
     @tornado.web.authenticated
     async def get(self):
-        metadata_only = True  # Optionally make this dynamic from query param later
+        metadata_only = True
         assert self.serverapp is not None
         raw_tools = find_tools(self.serverapp.extension_manager, return_metadata_only=metadata_only)
 

--- a/jupyter_server_ai_tools/models.py
+++ b/jupyter_server_ai_tools/models.py
@@ -17,6 +17,21 @@ def python_type_to_json_type(py_type: Any) -> str:
 
 
 class ToolDefinition(BaseModel):
+    """
+    A structured representation of a tool with an associated callable and metadata.
+
+    This model is used to register functions as tools in Jupyter server extensions.
+    Users can provide a function and optionally supply structured metadata describing
+    the tool's interface. If metadata is not provided, it is automatically inferred
+    from the callable's name, docstring, and type annotations.
+
+    Attributes:
+        callable (Callable): The Python function to be registered as a tool.
+        metadata (Optional[Dict[str, Any]]): A dictionary representing the tool's
+            metadata. This should follow a JSON Schema–like format. If not provided,
+            metadata will be inferred from the callable using `inspect` and `get_type_hints`.
+    """
+
     callable: Callable
     metadata: Optional[Dict[str, Any]] = None
 
@@ -25,7 +40,7 @@ class ToolDefinition(BaseModel):
         fn = values.get("callable")
         metadata = values.get("metadata")
 
-        if not metadata and fn:
+        if not metadata and fn:  # allows users to simply pass the callable
             sig = inspect.signature(fn)
             type_hints = get_type_hints(fn)
 
@@ -38,7 +53,7 @@ class ToolDefinition(BaseModel):
             values["metadata"] = {
                 "name": fn.__name__,
                 "description": fn.__doc__ or "",
-                "inputSchema": {
+                "inputSchema": {  # MCP uses inputSchema for paramter definitions
                     "type": "object",
                     "properties": properties,
                     "required": list(sig.parameters),

--- a/jupyter_server_ai_tools/models.py
+++ b/jupyter_server_ai_tools/models.py
@@ -1,7 +1,7 @@
 import inspect
 from typing import Any, Callable, Dict, Optional, get_type_hints
 
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, model_validator
 
 
 def python_type_to_json_type(py_type: Any) -> str:
@@ -35,7 +35,8 @@ class ToolDefinition(BaseModel):
     callable: Callable
     metadata: Optional[Dict[str, Any]] = None
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def fill_metadata(cls, values):
         fn = values.get("callable")
         metadata = values.get("metadata")

--- a/jupyter_server_ai_tools/models.py
+++ b/jupyter_server_ai_tools/models.py
@@ -1,0 +1,48 @@
+import inspect
+from typing import Any, Callable, Dict, Optional, get_type_hints
+
+from pydantic import BaseModel, root_validator
+
+
+def python_type_to_json_type(py_type: Any) -> str:
+    mapping = {
+        str: "string",
+        int: "integer",
+        float: "number",
+        bool: "boolean",
+        list: "array",
+        dict: "object",
+    }
+    return mapping.get(py_type, "string")
+
+
+class ToolDefinition(BaseModel):
+    callable: Callable
+    metadata: Optional[Dict[str, Any]] = None
+
+    @root_validator(pre=True)
+    def fill_metadata(cls, values):
+        fn = values.get("callable")
+        metadata = values.get("metadata")
+
+        if not metadata and fn:
+            sig = inspect.signature(fn)
+            type_hints = get_type_hints(fn)
+
+            properties = {}
+            for name, param in sig.parameters.items():
+                py_type = type_hints.get(name, str)
+                json_type = python_type_to_json_type(py_type)
+                properties[name] = {"type": json_type}
+
+            values["metadata"] = {
+                "name": fn.__name__,
+                "description": fn.__doc__ or "",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": properties,
+                    "required": list(sig.parameters),
+                },
+            }
+
+        return values

--- a/jupyter_server_ai_tools/schema.py
+++ b/jupyter_server_ai_tools/schema.py
@@ -1,0 +1,29 @@
+MCP_TOOL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "description": {"type": "string"},
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "type": {"type": "string", "enum": ["object"]},
+                "properties": {"type": "object"},
+                "required": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["type", "properties"],
+        },
+        "annotations": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "readOnlyHint": {"type": "boolean"},
+                "destructiveHint": {"type": "boolean"},
+                "idempotentHint": {"type": "boolean"},
+                "openWorldHint": {"type": "boolean"},
+            },
+            "additionalProperties": True,
+        },
+    },
+    "required": ["name", "inputSchema"],
+    "additionalProperties": False,
+}

--- a/jupyter_server_ai_tools/tool_registry.py
+++ b/jupyter_server_ai_tools/tool_registry.py
@@ -39,6 +39,7 @@ def find_tools(
                 tool_provider = getattr(module, "jupyter_server_extension_tools")
                 if callable(tool_provider):
                     tools = tool_provider()
+
                     if not isinstance(tools, list):
                         raise TypeError(
                             f"`jupyter_server_extension_tools()` in '{ext_name}' must return a list"
@@ -56,7 +57,7 @@ def find_tools(
                                 raise ValueError("Tool metadata must be a dict")
                             discovered.append(tool.metadata)
                         else:
-                            discovered.append(tool.dict())
+                            discovered.append(tool.model_dump(mode="python"))
         except jsonschema.ValidationError as ve:
             print(f"[find_tools] Schema validation error in '{ext_name}': {ve.message}")
         except Exception as e:

--- a/jupyter_server_ai_tools/tool_registry.py
+++ b/jupyter_server_ai_tools/tool_registry.py
@@ -1,0 +1,65 @@
+import importlib
+from typing import Any, Dict, List, Optional
+
+import jsonschema
+
+from jupyter_server_ai_tools.models import ToolDefinition
+
+
+def find_tools(
+    extension_manager, schema: Optional[dict] = None, return_metadata_only: bool = False
+) -> List[Dict[str, Any]]:
+    """
+    Discover and return tools from installed Jupyter server extensions.
+
+    Each extension must expose a `jupyter_server_extension_tools()` function
+    that returns a list of `ToolDefinition` instances.
+
+    Parameters:
+        extension_manager: The Jupyter Server extension manager instance.
+        schema (Optional[dict]): An optional JSON Schema to validate each tool's
+            metadata against. Validation is only applied if the user has provided a
+            schema to validate against.
+        return_metadata_only (bool): If True, return only the `metadata` for each tool.
+            If False (default), return the full dictionary representation of the tool,
+            including both `metadata` and `callable`.
+
+    Returns:
+        A list of dictionaries, each representing a tool. The contents depend on
+        `return_metadata_only`. Tools without required fields or invalid structure
+        will raise errors or be skipped.
+    """
+    discovered = []
+
+    for ext_name in extension_manager.extensions:
+        try:
+            module = importlib.import_module(ext_name)
+
+            if hasattr(module, "jupyter_server_extension_tools"):
+                tool_provider = getattr(module, "jupyter_server_extension_tools")
+                if callable(tool_provider):
+                    tools = tool_provider()
+                    if not isinstance(tools, list):
+                        raise TypeError(
+                            f"`jupyter_server_extension_tools()` in '{ext_name}' must return a list"
+                        )
+
+                    for tool in tools:
+                        if not isinstance(tool, ToolDefinition):
+                            raise TypeError(f"Tool from '{ext_name}' must be a ToolDefinition")
+
+                        if schema:
+                            jsonschema.validate(instance=tool.metadata, schema=schema)
+
+                        if return_metadata_only:
+                            if not isinstance(tool.metadata, dict):
+                                raise ValueError("Tool metadata must be a dict")
+                            discovered.append(tool.metadata)
+                        else:
+                            discovered.append(tool.dict())
+        except jsonschema.ValidationError as ve:
+            print(f"[find_tools] Schema validation error in '{ext_name}': {ve.message}")
+        except Exception as e:
+            print(f"[find_tools] Failed to load tools from '{ext_name}': {e}")
+
+    return discovered

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jupyter_server_ai_tools"
-version = "0.1.0"
 authors = [{name = "Abigayle Mercer", email = "abigaylemercer@gmail.com"}]
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = ["jupyter_server>=1.6,<3"]
 [project.optional-dependencies]
 test = [
   "pytest>=7.0",
-  "pytest-jupyter[server]>=0.6"
+  "pytest-jupyter[server]>=0.6",
+  "pytest-asyncio>=0.21"
 ]
 lint = [
   "black>=22.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ lint = [
   "mypy>=0.990",
   "mdformat>=0.7.16",
   "mdformat-gfm>=0.3.5",    
-  "types-jsonschema"    
+  "types-jsonschema",
+  "pydantic>=1.10"
 ]
 
 [project.license]
@@ -60,6 +61,7 @@ filterwarnings = [
 check_untyped_defs = true
 pretty = true
 show_error_codes = true
+ignore_missing_imports = true
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ lint = [
   "ruff>=0.0.156",
   "mypy>=0.990",
   "mdformat>=0.7.16",
-  "mdformat-gfm>=0.3.5"
+  "mdformat-gfm>=0.3.5",    
+  "types-jsonschema"    
 ]
 
 [project.license]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jupyter_server_ai_tools"
+dynamic = ["version"]
 authors = [{name = "Abigayle Mercer", email = "abigaylemercer@gmail.com"}]
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Framework :: Jupyter",
 ]
-dependencies = ["jupyter_server>=1.6,<3"]
+dependencies = ["jupyter_server>=1.6,<3", "pydantic>=1.10"]
 
 [project.optional-dependencies]
 test = [

--- a/tests/mockextensions/mockext_tool.py
+++ b/tests/mockextensions/mockext_tool.py
@@ -1,0 +1,19 @@
+from jupyter_server_ai_tools.models import ToolDefinition
+
+
+def say_hello(name: str):
+    '''Say hello to a user.'''
+    return f"Hello, {name}!"
+
+
+def jupyter_server_extension_tools():
+    tool = ToolDefinition(callable=say_hello)
+    return [tool]
+
+
+def _jupyter_server_extension_points():
+    return [{"module": "tests.mockextensions.mockext_tool"}]
+
+
+def _load_jupyter_server_extension(serverapp):
+    serverapp.log.info("Mock extension loaded.")

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,2 +1,27 @@
-def test_smoke():
-    assert True
+import json
+
+import pytest
+
+
+@pytest.fixture
+def jp_server_config():
+    return {
+        "ServerApp": {
+            "jpserver_extensions": {
+                "jupyter_server_ai_tools": True,
+                "tests.mockextensions.mockext_tool": True,
+            }
+        }
+    }
+
+
+async def test_tools_handler_with_mock_extension(jp_fetch):
+    response = await jp_fetch("jupyter_server_ai_tools", "tools")
+    assert response.code == 200
+
+    payload = json.loads(response.body)
+    assert "discovered_tools" in payload
+    tools = payload["discovered_tools"]
+    assert isinstance(tools, list)
+    assert tools[0]["name"] == "say_hello"
+    assert "inputSchema" in tools[0]

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,0 +1,63 @@
+from types import ModuleType
+from typing import Any, cast
+from unittest.mock import Mock, patch
+
+from jupyter_server_ai_tools.models import ToolDefinition
+from jupyter_server_ai_tools.tool_registry import find_tools
+
+
+def test_tool_definition_metadata_inference():
+    def greet(name: str, age: int):
+        """Say hello"""
+        return f"Hello {name}, age {age}"
+
+    tool = ToolDefinition(callable=greet)
+    assert tool.metadata is not None
+
+    assert tool.metadata["name"] == "greet"
+    assert tool.metadata["description"] == "Say hello"
+    assert tool.metadata["inputSchema"]["required"] == ["name", "age"]
+    assert tool.metadata["inputSchema"]["properties"]["name"]["type"] == "string"
+    assert tool.metadata["inputSchema"]["properties"]["age"]["type"] == "integer"
+
+
+def test_find_tools_returns_metadata_only():
+    def say_hi(user: str):
+        """Simple tool"""
+        return f"Hi {user}"
+
+    tool = ToolDefinition(callable=say_hi)
+
+    fake_module = cast(Any, ModuleType("fake_ext"))
+    fake_module.jupyter_server_extension_tools = lambda: [tool]
+
+    extension_manager = Mock()
+    extension_manager.extensions = ["fake_ext"]
+
+    with patch("importlib.import_module", return_value=fake_module):
+        result = find_tools(extension_manager, return_metadata_only=True)
+
+    assert isinstance(result, list)
+    assert result[0]["name"] == "say_hi"
+    assert "callable" not in result[0]
+
+
+def test_find_tools_returns_full_tool_definition():
+    def echo(msg: str):
+        """Repeat message"""
+        return msg
+
+    tool = ToolDefinition(callable=echo)
+
+    fake_module = cast(Any, ModuleType("fake_ext"))
+    fake_module.jupyter_server_extension_tools = lambda: [tool]
+
+    extension_manager = Mock()
+    extension_manager.extensions = ["another_ext"]
+
+    with patch("importlib.import_module", return_value=fake_module):
+        result = find_tools(extension_manager, return_metadata_only=False)
+
+    assert isinstance(result, list)
+    assert result[0]["metadata"]["name"] == "echo"
+    assert callable(result[0]["callable"])

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,27 +1,95 @@
+import logging
 from types import ModuleType
 from typing import Any, cast
 from unittest.mock import Mock, patch
 
+import pytest
+
 from jupyter_server_ai_tools.models import ToolDefinition
 from jupyter_server_ai_tools.tool_registry import find_tools
 
+# ---------------------------------------------------------------------
+# ToolDefinition Tests
+# ---------------------------------------------------------------------
+
 
 def test_tool_definition_metadata_inference():
+    """
+    Test that ToolDefinition correctly infers metadata from a function's
+    name, docstring, parameter names, and type annotations.
+    """
+
     def greet(name: str, age: int):
         """Say hello"""
         return f"Hello {name}, age {age}"
 
     tool = ToolDefinition(callable=greet)
-    assert tool.metadata is not None
+    metadata = tool.metadata
 
-    assert tool.metadata["name"] == "greet"
-    assert tool.metadata["description"] == "Say hello"
-    assert tool.metadata["inputSchema"]["required"] == ["name", "age"]
-    assert tool.metadata["inputSchema"]["properties"]["name"]["type"] == "string"
-    assert tool.metadata["inputSchema"]["properties"]["age"]["type"] == "integer"
+    assert metadata is not None
+    assert metadata["name"] == "greet"
+    assert metadata["description"] == "Say hello"
+    assert metadata["inputSchema"]["required"] == ["name", "age"]
+    assert metadata["inputSchema"]["properties"]["name"]["type"] == "string"
+    assert metadata["inputSchema"]["properties"]["age"]["type"] == "integer"
+
+
+def test_metadata_infers_all_supported_types():
+    """
+    Test that ToolDefinition infers all supported JSON types correctly from Python types.
+    """
+
+    def func(a: str, b: int, c: float, d: bool, e: list, f: dict):
+        """Covers all mapped Python types"""
+        return None
+
+    tool = ToolDefinition(callable=func)
+    metadata = tool.metadata
+
+    assert metadata is not None
+    props = metadata["inputSchema"]["properties"]
+    required = metadata["inputSchema"]["required"]
+
+    assert set(required) == {"a", "b", "c", "d", "e", "f"}
+    assert props["a"]["type"] == "string"
+    assert props["b"]["type"] == "integer"
+    assert props["c"]["type"] == "number"
+    assert props["d"]["type"] == "boolean"
+    assert props["e"]["type"] == "array"
+    assert props["f"]["type"] == "object"
+
+
+def test_tooldefinition_raises_on_invalid_metadata():
+    """
+    Test that invalid MCP metadata (missing inputSchema) raises a ValueError.
+    """
+
+    def greet(name: str):
+        return f"Hi {name}"
+
+    invalid_metadata = {
+        "name": "greet",
+        "description": "Greet someone",
+        # Missing "inputSchema"
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        ToolDefinition(callable=greet, metadata=invalid_metadata)
+
+    assert "inputSchema" in str(exc_info.value)
+    assert "greet" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------
+# find_tools() Tests
+# ---------------------------------------------------------------------
 
 
 def test_find_tools_returns_metadata_only():
+    """
+    Test that find_tools() returns only metadata when return_metadata_only=True.
+    """
+
     def say_hi(user: str):
         """Simple tool"""
         return f"Hi {user}"
@@ -43,6 +111,11 @@ def test_find_tools_returns_metadata_only():
 
 
 def test_find_tools_returns_full_tool_definition():
+    """
+    Test that find_tools() returns full ToolDefinition dicts with callable when
+    return_metadata_only=False.
+    """
+
     def echo(msg: str):
         """Repeat message"""
         return msg
@@ -61,3 +134,39 @@ def test_find_tools_returns_full_tool_definition():
     assert isinstance(result, list)
     assert result[0]["metadata"]["name"] == "echo"
     assert callable(result[0]["callable"])
+
+
+def test_find_tools_skips_non_tooldefinition(caplog):
+    """
+    Test that find_tools() skips invalid tool entries that are not ToolDefinition instances.
+    """
+    bad_tool = {"name": "not_a_real_tool", "description": "I am not a ToolDefinition instance"}
+
+    fake_module = cast(Any, ModuleType("bad_ext"))
+    fake_module.jupyter_server_extension_tools = lambda: [bad_tool]
+
+    extension_manager = Mock()
+    extension_manager.extensions = ["bad_ext"]
+
+    with patch("importlib.import_module", return_value=fake_module), caplog.at_level(
+        logging.WARNING
+    ):
+        tools = find_tools(extension_manager)
+
+    assert tools == []
+    assert any("Tool from 'bad_ext' is not a ToolDefinition" in m for m in caplog.messages)
+
+
+def test_find_tools_skips_extensions_without_hook():
+    """
+    Test that find_tools() skips extensions that do not define jupyter_server_extension_tools().
+    """
+    fake_module = cast(Any, ModuleType("no_hook_ext"))  # No tool function
+
+    extension_manager = Mock()
+    extension_manager.extensions = ["no_hook_ext"]
+
+    with patch("importlib.import_module", return_value=fake_module):
+        result = find_tools(extension_manager)
+
+    assert result == []


### PR DESCRIPTION
This PR introduces the foundation for a **tool discovery system** for Jupyter server extensions.

It provides a clean, typed API for:
- Defining callable tools with optional metadata
- Discovering and aggregating tools across installed extensions
- Optionally validating tool metadata via a provided JSON Schema

This lays the groundwork for building agent systems that can dynamically discover and bind tools.
---

## 🔧 What this adds

### 1. `ToolDefinition` class (`models.py`)

A Pydantic model representing a tool with two fields:
- `callable`: the function to invoke
- `metadata`: a dictionary describing the tool (name, description, inputSchema)

If `metadata` is not provided, it is **inferred automatically** using Python introspection:
- `name`: inferred from `fn.__name__`
- `description`: inferred from the function docstring
- `inputSchema`: inferred from the function's parameters and type hints using `inspect` and `get_type_hints`

This is MCP compatible by default, but a user could provide metadata that adheres to another frameworks tool definition. 

### 2. `find_tools()` function (`tool_registry.py`)

This function:
- Iterates through all installed Jupyter extensions
- Looks for a `jupyter_server_extension_tools()` hook
- Expects each hook to return a list of `ToolDefinition` instances
- Returns either:
  - Only the metadata (`return_metadata_only=True`)
  - Or the full tool definitions (including callables)

If a `schema` is provided, each tool’s metadata is validated against it using `jsonschema.validate()`.
This would return something like: 
```
[
  {
    "callable": <function greet at 0x...>,
    "metadata": {
      "name": "greet",
      "description": "Say hello to someone.",
      "inputSchema": {
        "type": "object",
        "properties": {
          "name": { "type": "string" }
        },
        "required": ["name"]
      }
    }
  }
]
```

---

## How to use it

Contributors can expose tools like this in their server extension:

```python
from jupyter_server_ai_tools.models import ToolDefinition

def greet(name: str):
    """Say hello to someone."""
    return f"Hello, {name}!"

def jupyter_server_extension_tools():
    return [ToolDefinition(callable=greet)]
```

## Validation Considerations

Schema validation is **optional** and only happens inside `find_tools()` when:

- A schema is provided to `find_tools(schema=...)`

No validation is performed when constructing a `ToolDefinition`. 

### Tradeoff

This design means that a contributor could pass invalid metadata (e.g. with typos or incorrect structure), and it would not raise an error until **discovery time** via `find_tools()`.

We may want to consider:

- Introducing a flag to enable validation during `ToolDefinition` creation, however what schema to validate against is unclear, whether it should be one the user registers when creating tools or using MCP by default.
- When the user does not provide metadata, its inferred and built in the MCP style, so if the user provided a schema in find_tools that wasn't compatible with this, all of those tools would be excluded. 

**TLDR:** We need to decide where validation should happen, and whether we want to provide a default or not. 

@Zsailer @ellisonbg Let me know what you think of: 
- function names
- validation 
- introducing functionality for running tools


