### PR TITLE
Fix find tools

### DIFF
--- a/jupyter_server_ai_tools/models.py
+++ b/jupyter_server_ai_tools/models.py
@@ -74,16 +74,32 @@ class Toolkit(BaseModel):
         self, read: bool = False, write: bool = False, execute: bool = False, delete: bool = False
     ) -> ToolSet[Tool]:
         toolset = ToolSet()
-
+        
+        # Check if any parameters are True
+        any_param_true = read or write or execute or delete
+        
         for tool in self.tools:
-            if (
-                (delete and tool.delete)
-                or (execute and tool.execute)
-                or (write and tool.write)
-                or (read and tool.read)
-            ):
+            # If no parameters are True, include all tools
+            if not any_param_true:
                 toolset.add(tool)
-
+                continue
+                
+            # Check if tool matches all specified criteria
+            matches_all = True
+            
+            # Only check criteria that were explicitly set to True
+            if read and not tool.read:
+                matches_all = False
+            if write and not tool.write:
+                matches_all = False
+            if execute and not tool.execute:
+                matches_all = False
+            if delete and not tool.delete:
+                matches_all = False
+                
+            if matches_all:
+                toolset.add(tool)
+                
         return toolset
 
     def __eq__(self, other):

--- a/jupyter_server_ai_tools/models.py
+++ b/jupyter_server_ai_tools/models.py
@@ -45,13 +45,6 @@ class Tool(BaseModel):
 
         return self
 
-    @model_validator(mode="after")
-    def resolve_modes(self):
-        if self.write:
-            self.read = True
-
-        return self
-
     def __eq__(self, other):
         if not isinstance(other, Tool):
             return False
@@ -85,7 +78,7 @@ class Toolkit(BaseModel):
         for tool in self.tools:
             if (
                 (delete and tool.delete)
-                or (execute and not tool.execute)
+                or (execute and tool.execute)
                 or (write and tool.write)
                 or (read and tool.read)
             ):

--- a/tests/test_toolkit_registry.py
+++ b/tests/test_toolkit_registry.py
@@ -36,11 +36,11 @@ def test_toolkit_find_tools():
 
     # Test 2: Find tools with read permission
     read_tools = toolkit.find_tools(read=True)
-    assert len(read_tools) == 5
+    assert len(read_tools) == 3
     assert read_only_tool in read_tools
-    assert write_tool in read_tools  # write implies read
+    assert write_tool not in read_tools  # write implies read
     assert read_execute_tool in read_tools
-    assert write_execute_tool in read_tools
+    assert write_execute_tool not in read_tools
     assert all_perms_tool in read_tools
     assert execute_tool not in read_tools
     assert delete_tool not in read_tools
@@ -62,15 +62,15 @@ def test_toolkit_find_tools():
     execute_tools = toolkit.find_tools(execute=True)
     assert len(execute_tools) == 4
     assert (
-        execute_tool not in execute_tools
-    )  # Because the condition is (execute and not tool.execute)
-    assert read_execute_tool not in execute_tools
-    assert write_execute_tool not in execute_tools
-    assert all_perms_tool not in execute_tools
-    assert read_only_tool in execute_tools
-    assert write_tool in execute_tools
-    assert delete_tool in execute_tools
-    assert no_perms_tool in execute_tools
+        execute_tool in execute_tools
+    )
+    assert read_execute_tool in execute_tools
+    assert write_execute_tool in execute_tools
+    assert all_perms_tool in execute_tools
+    assert read_only_tool not in execute_tools
+    assert write_tool not in execute_tools
+    assert delete_tool not in execute_tools
+    assert no_perms_tool not in execute_tools
 
     # Test 5: Find tools with delete permission
     delete_tools = toolkit.find_tools(delete=True)
@@ -86,12 +86,12 @@ def test_toolkit_find_tools():
 
     # Test 6: Combined permissions (read and delete)
     read_delete_tools = toolkit.find_tools(read=True, delete=True)
-    assert len(read_delete_tools) == 6
+    assert len(read_delete_tools) == 4
     assert read_only_tool in read_delete_tools
-    assert write_tool in read_delete_tools
+    assert write_tool not in read_delete_tools
     assert delete_tool in read_delete_tools
     assert read_execute_tool in read_delete_tools
-    assert write_execute_tool in read_delete_tools
+    assert write_execute_tool not in read_delete_tools
     assert all_perms_tool in read_delete_tools
     assert execute_tool not in read_delete_tools
     assert no_perms_tool not in read_delete_tools
@@ -102,7 +102,7 @@ def test_toolkit_find_tools():
     assert read_only_tool in all_perm_tools
     assert write_tool in all_perm_tools
     assert delete_tool in all_perm_tools
-    assert no_perms_tool in all_perm_tools
+    assert no_perms_tool not in all_perm_tools
     assert read_execute_tool in all_perm_tools
     assert write_execute_tool in all_perm_tools
     assert all_perms_tool in all_perm_tools


### PR DESCRIPTION
## Summary

This PR fixes the logic in the `find_tools` method of the `Toolkit` class to return tools taking into consideration only the flags that are passed as True. This change ensures more precise tool filtering when multiple criteria are specified.

### Example usage of the updated find_tools method

```python
# Create a toolkit
toolkit = Toolkit(name="example_toolkit")

# Create tools with different permission combinations
tool1 = Tool(callable=lambda: None, name="read_only", read=True)
tool2 = Tool(callable=lambda: None, name="read_write", read=True, write=True)
tool3 = Tool(callable=lambda: None, name="all_permissions", read=True, write=True, execute=True, delete=True)
toolkit.add_tool(tool1)
toolkit.add_tool(tool2)
toolkit.add_tool(tool3)

# Example 1: Default behavior - returns all tools
all_tools = toolkit.find_tools()
print("Default (no filters):", [tool.name for tool in all_tools])
# Output: Default (no filters): ['read_only', 'read_write', 'all_permissions']

# Example 2: Single permission filter - returns tools with read permission
read_tools = toolkit.find_tools(read=True)
print("Read=True:", [tool.name for tool in read_tools])
# Output: Read=True: ['read_only', 'read_write', 'all_permissions']

# Example 3: Multiple permission filter - returns tools with BOTH read AND write permissions
read_write_tools = toolkit.find_tools(read=True, write=True)
print("Read=True, Write=True:", [tool.name for tool in read_write_tools])
# Output: Read=True, Write=True: ['read_write', 'all_permissions']

# Example 4: All permissions filter - returns only tools with ALL permissions
all_perm_tools = toolkit.find_tools(read=True, write=True, execute=True, delete=True)
print("All permissions=True:", [tool.name for tool in all_perm_tools])
# Output: All permissions=True: ['all_permissions']
```
